### PR TITLE
Add hardcode of production value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - logging.env
     ports:
       - "8100:80"
+    restart: unless-stopped
 
 #               _
 # __      _____| |__
@@ -125,6 +126,7 @@ services:
       - mongo
     ports:
       - "127.0.0.1:${GH_CPAN_SITE_PORT:-3000}:3000"
+    restart: unless-stopped
 
 #        _ _   _           _                           _
 #   __ _(_) |_| |__  _   _| |__    _ __ ___   ___  ___| |_ ___
@@ -240,6 +242,7 @@ services:
     image: mvertes/alpine-mongo:latest
     networks:
       - mongo
+    restart: unless-stopped
 
 #  _   _ _____ _______        _____  ____  _  ______
 # | \ | | ____|_   _\ \      / / _ \|  _ \| |/ / ___|

--- a/logging.env
+++ b/logging.env
@@ -2,7 +2,7 @@
 HONEYCOMB_WRITE_KEY=XXX
 
 ## HONEYCOMB_DATASET: 'dev' or 'production'
-HONEYCOMB_DATASET=YYY
+HONEYCOMB_DATASET=production
 
 ## This is honeycomb magic
 ROUTE_URIS=honeycomb://localhost


### PR DESCRIPTION
As this is only meant to be run on production, setting the dataset for
honeycomb.io to production for always and forever.