### PR TITLE
Change mongodb image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,7 +239,7 @@ services:
 #
 
   mongodb:
-    image: mvertes/alpine-mongo:latest
+    image: mongo:latest
     networks:
       - mongo
     restart: unless-stopped


### PR DESCRIPTION
Use the official mongodb image even though it's xenial and not small
alpine. For some reason the alpine image kept network disconnecting
causing github-meets-cpan to go down.