### PR TITLE
Add healthcheck to MongoDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,6 +242,12 @@ services:
     image: mongo:latest
     networks:
       - mongo
+    healthcheck:
+      interval: 10s
+      timeout: 10s
+      retries: 0
+      start_period: 40s
+      test: echo 'db.runCommand("ping").ok' | mongo mongodb:27017/test --quiet
     restart: unless-stopped
 
 #  _   _ _____ _______        _____  ____  _  ______


### PR DESCRIPTION
Simple healthcheck for docker to execute to prove that the container is
running correctly.