### PR TITLE
Remove unused volume definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,9 +258,9 @@ services:
 #
 
 networks:
-  elasticsearch:
-  database:
-  web:
+  # elasticsearch:
+  # database:
+  # web:
   mongo:
 
 # __     _____  _    _   _ __  __ _____ ____


### PR DESCRIPTION
These volumes are used in development but not in production as of yet,
so commenting them out so that `docker-compose` doesn't warn of their
existence until such a time as they are needed in production.