### PR TITLE
Enable traefik for grep.metacpan.org

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,35 @@ version: "3.4"
 
 services:
 
+#     __                  _____ __
+#    / /__________ ____  / __(_) /__
+#   / __/ ___/ __ `/ _ \/ /_/ / //_/         __
+#  / /_/ /  / /_/ /  __/ __/ / ,<          _| =\__
+#  \__/_/   \__,_/\___/_/ /_/_/|_|        /o____o_\
+
+
+  traefik:
+    # The official v2.0 Traefik docker image
+    image: traefik:v2.0
+    networks:
+      - traefik-network
+    # Enables the web UI and tells Traefik to listen to docker
+    command:
+      - "--api.insecure=false"
+      - "--api.dashboard=false"
+      - "--providers.docker"
+    ports:
+      # The HTTP port
+      - "80:80"
+      # The Web UI (enabled by --api.insecure=true)
+      - "8080:8080"
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock
+      - "traefik.http.routers.api.rule=Host(`traefik.metacpan.org`)"
+      - "traefik.http.routers.api.service=api@internal"
+      - "traefik.http.routers.api.middlewares=auth"
+      - "traefik.http.middlewares.auth.basicauth.users=mcadmin:$xyz$abcd"
 #  _                                   _
 # | | ___   __ _ ___ _ __   ___  _   _| |_
 # | |/ _ \ / _` / __| '_ \ / _ \| | | | __|
@@ -29,7 +58,8 @@ services:
     ports:
       - "8100:80"
     restart: unless-stopped
-
+    labels:
+      - "traefik.enable=false"
 #               _
 # __      _____| |__
 # \ \ /\ / / _ \ '_ \
@@ -128,6 +158,8 @@ services:
     ports:
       - "127.0.0.1:${GH_CPAN_SITE_PORT:-3000}:3000"
     restart: unless-stopped
+    labels:
+      - "traefik.enable=false"
 
 #        _ _   _           _                           _
 #   __ _(_) |_| |__  _   _| |__    _ __ ___   ___  ___| |_ ___
@@ -156,6 +188,8 @@ services:
         read_only: true
     networks:
       - mongo
+    labels:
+      - "traefik.enable=false"
 
 #   __ _ _ __ ___ _ __
 #  / _` | '__/ _ \ '_ \
@@ -165,6 +199,8 @@ services:
 #  |___/         |_|
 
   grep:
+    depends_on:
+      - traefik
     image: metacpan/metacpan-grep-front-end:latest
     volumes:
       - type: volume
@@ -176,9 +212,10 @@ services:
     ports:
       - "127.0.0.1:${GREP_SITE_PORT:-3001}:3000"
     networks:
-      - grep
+      - traefik-network
     labels:
       - traefik.http.routers.grep.rule=Host(`grep.metacpan.org`)
+      - traefik.http.services.grep-web.loadbalancer.server.port=3000
 
 #  ____    _  _____  _    ____    _    ____  _____ ____
 # |  _ \  / \|_   _|/ \  | __ )  / \  / ___|| ____/ ___|
@@ -273,7 +310,8 @@ services:
       start_period: 40s
       test: echo 'db.runCommand("ping").ok' | mongo mongodb:27017/test --quiet
     restart: unless-stopped
-
+    labels:
+      - "traefik.enable=false"
 #  _   _ _____ _______        _____  ____  _  ______
 # | \ | | ____|_   _\ \      / / _ \|  _ \| |/ / ___|
 # |  \| |  _|   | |  \ \ /\ / / | | | |_) | ' /\___ \
@@ -286,7 +324,7 @@ networks:
   # database:
   # web:
   mongo:
-  grep:
+  traefik-network:
 
 # __     _____  _    _   _ __  __ _____ ____
 # \ \   / / _ \| |  | | | |  \/  | ____/ ___|


### PR DESCRIPTION
For now only enable traefik for grep.metacpan.org
Note: the dashboard is disable

copy: @ssoriche 