### PR TITLE
Remove volume option for metacpan_git_shared

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,8 +341,4 @@ volumes:
   elasticsearch_test:
   pgdb-data:
   metacpan_git_shared:
-    driver_opts:
-      type: none
-      device: ${MC_CONF_PRIVATE_DIR}/metacpan-cpan-extracted
-      o: bind
-
+    external: true


### PR DESCRIPTION
The declaration of the volume options is causing issues with deploying
to production as the volume is already in place and docker won't let it
be redefined. By moving the declaration to an external, the volume isn't
redefined according to compose and everything progresses.